### PR TITLE
fix: remove incorrect middle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
-  <a href="https://smartui.lambdatest.com/"><img src="https://img.shields.io/badge/SmartUI-Visual%20Testing-blue.svg?style=for-the-badge&labelColor=000" alt="SmartUI Visual Testing"></a>
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 


### PR DESCRIPTION
The middle badge linked to a non-package-registry URL. Removed it — repos without published packages should only have the MADE BY + Community badges.